### PR TITLE
Add li (list item) support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ const rehypeAttrs: Plugin<[RehypeAttrsOptions?], Root> = (options = {}) => {
         }
       }
       let rootnode = parent as Root
-      if ((/^(em|strong|b|a|i|p|pre|kbd|blockquote|h(1|2|3|4|5|6)|code|table|img|del|ul|ol)$/.test(node.tagName) || rootnode.type == "root") && parent && Array.isArray(parent.children) && typeof index === 'number') {
+      if ((/^(em|strong|b|a|i|p|pre|kbd|blockquote|h(1|2|3|4|5|6)|code|table|img|del|ul|ol|li)$/.test(node.tagName) || rootnode.type == "root") && parent && Array.isArray(parent.children) && typeof index === 'number') {
         const child = nextChild(parent.children, index, '', commentStart, commentEnd)
         if (child) {
           const attr = getCommentObject(child as Comment, commentStart, commentEnd)


### PR DESCRIPTION
Add li (list item) support

<img width="556" height="141" alt="image" src="https://github.com/user-attachments/assets/1975a17a-350d-479e-b274-51e0b64dfb60" />

Note this works only with raw html `<li>` in the markdown:
```
<ul>
<li>Write clean, maintainable React code</li><!--rehype:data-testid=frontend-intro-purpose-clean-->
<li>Understand and apply component-based architecture</li><!--rehype:data-testid=frontend-intro-purpose-architecture-->
<li>Implement proper state management patterns</li><!--rehype:data-testid=frontend-intro-purpose-state-->
<li>Follow TypeScript best practices for type safety</li><!--rehype:data-testid=frontend-intro-purpose-typescript-->
</ul>
<!--rehype:data-testid=frontend-intro-purpose-list-->
```

It does not work with a traditional markdown list:
```
- Write clean, maintainable React code<!--rehype:data-testid=frontend-intro-purpose-clean-->
- Understand and apply component-based architecture<!--rehype:data-testid=frontend-intro-purpose-architecture-->
- Implement proper state management patterns<!--rehype:data-testid=frontend-intro-purpose-state-->
- Follow TypeScript best practices for type safety<!--rehype:data-testid=frontend-intro-purpose-typescript-->
<!--rehype:data-testid=frontend-intro-purpose-list-->
```